### PR TITLE
Fix #5 and #6: destroy() teardown API and SDP payload validation

### DIFF
--- a/p2p-addon.js
+++ b/p2p-addon.js
@@ -73,6 +73,17 @@ export class P2PAddon extends EventTarget {
         if (this.ui) this.ui.hide();
     }
 
+    /**
+     * Fully tears down all P2P resources: closes peer connections, BroadcastChannel,
+     * window event listeners, QR scanner, and removes the modal DOM. After calling
+     * destroy(), call init() again to reinitialize for a new session.
+     */
+    destroy() {
+        this.ui?.destroy();
+        this.ui = null;
+        this.peerNode?.destroy();
+    }
+
     send(data) {
         if (typeof data !== 'string') {
             data = JSON.stringify(data);

--- a/p2p-core.js
+++ b/p2p-core.js
@@ -27,6 +27,28 @@ export class ConnectionUtils {
             throw new Error(`Decompression failed: ${e.message}`);
         }
     }
+
+    /**
+     * Validates that a signaling payload has the expected structure before
+     * passing it to WebRTC internals. Throws a descriptive Error on failure.
+     * @param {*} data - The deserialized payload object.
+     * @param {string[]} [requiredFields=['peerId','sessionDesc']] - Fields that must be present.
+     * @returns {object} The validated data object (pass-through).
+     */
+    static validatePayload(data, requiredFields = ['peerId', 'sessionDesc']) {
+        if (!data || typeof data !== 'object' || Array.isArray(data)) {
+            throw new Error('Invalid payload: expected a plain object');
+        }
+        for (const field of requiredFields) {
+            if (!(field in data)) {
+                throw new Error(`Invalid payload: missing required field "${field}"`);
+            }
+        }
+        if (data.sessionDesc && (typeof data.sessionDesc.type !== 'string' || typeof data.sessionDesc.sdp !== 'string')) {
+            throw new Error('Invalid payload: sessionDesc must have string fields "type" and "sdp"');
+        }
+        return data;
+    }
 }
 
 // ==========================================
@@ -122,8 +144,10 @@ export class PeerManager extends EventTarget {
                 this.broadcast(data, peerId);
             }
 
+            // Destructure only the expected fields to avoid merging arbitrary keys
+            const { text, from } = parsed;
             this.dispatchEvent(new CustomEvent('message', { 
-                detail: Object.assign({}, parsed, { incoming: true, peerId }) 
+                detail: { text, from, incoming: true, peerId } 
             }));
         };
     }
@@ -151,6 +175,18 @@ export class PeerManager extends EventTarget {
         } else {
             this.dispatchEvent(new CustomEvent('diagnostic', { detail: { type: 'error', msg: 'Cannot send, no channels open.' }}));
         }
+    }
+
+    /**
+     * Closes all peer connections and data channels, then clears the peers Map.
+     * After destroy(), this instance should not be reused.
+     */
+    destroy() {
+        this.peers.forEach((peerData) => {
+            try { peerData.dataChannel?.close(); } catch(_) {}
+            try { peerData.connection.close(); } catch(_) {}
+        });
+        this.peers.clear();
     }
 
     async createOffer() {

--- a/p2p-integration-guide.md
+++ b/p2p-integration-guide.md
@@ -36,6 +36,17 @@ document.getElementById('my-multiplayer-btn').addEventListener('click', () => {
 ### `hideUI()`
 Closes the multiplayer connection modal.
 
+### `destroy()`
+Fully tears down all P2P resources: closes all `RTCPeerConnection` instances, the `BroadcastChannel`,
+window event listeners, any active QR scanner, and removes the injected modal DOM. Call this when the
+player leaves the lobby or the round ends, then call `init()` again to reinitialize for a new session.
+```javascript
+// e.g., when the game round ends
+multiplayer.destroy();
+// Later, to start a fresh session:
+await multiplayer.init();
+```
+
 ### `send(data)`
 Sends data to the connected peer over the WebRTC data channel. Automatically stringifies JSON objects.
 ```javascript
@@ -48,11 +59,12 @@ multiplayer.send({ player: 1, action: "jump", x: 100, y: 200 });
 The addon extends `EventTarget`, allowing you to listen using standard `addEventListener`.
 
 #### Event: `status`
-Fired when the connection state changes.
+Fired when the connection state changes. `event.detail` is an object `{ peerId, status }`.
 ```javascript
 multiplayer.addEventListener('status', (event) => {
-    console.log("Connection status:", event.detail); 
-    // e.g., "connected", "disconnected", "connecting"
+    const { peerId, status } = event.detail;
+    console.log(`Peer ${peerId} is now: ${status}`);
+    // status values: "connected", "disconnected", "failed", "checking", ...
 });
 ```
 

--- a/p2p-ui.js
+++ b/p2p-ui.js
@@ -34,7 +34,8 @@ export class P2PUIManager {
         };
 
         // --- Channel 2: localStorage ---
-        window.addEventListener('storage', (e) => {
+        // Store ref so we can removeEventListener in destroy()
+        this._storageListener = (e) => {
             if (e.key === 'p2p-answer-forward' && e.newValue) {
                 try {
                     const data = JSON.parse(e.newValue);
@@ -42,19 +43,28 @@ export class P2PUIManager {
                     this._tryApplyAnswer(data, 'localStorage');
                 } catch(_) {}
             }
-        });
+        };
+        window.addEventListener('storage', this._storageListener);
 
         // --- Channel 3: window.postMessage (host receives answer from joiner tab it opened) ---
-        window.addEventListener('message', (e) => {
+        // Store ref so we can removeEventListener in destroy()
+        this._messageListener = (e) => {
             // Only accept messages from same origin
             if (e.origin !== window.location.origin) return;
             if (e.data && e.data.type === 'p2p-answer') {
                 this._tryApplyAnswer(e.data.payload, 'window.postMessage');
             }
-        });
+        };
+        window.addEventListener('message', this._messageListener);
     }
 
     _tryApplyAnswer(data, source) {
+        try {
+            ConnectionUtils.validatePayload(data);
+        } catch (e) {
+            this.logDiag('warn', `Ignoring malformed answer from ${source}: ${e.message}`);
+            return;
+        }
         if (this.peerNode.peers.has(data.peerId)) {
             this.logDiag('info', `Applying Answer from ${source}.`);
             this.peerNode.acceptAnswer(data);
@@ -88,6 +98,7 @@ export class P2PUIManager {
             this.logDiag('info', `URL ${type} detected. Ingesting...`);
             const decompressed = await ConnectionUtils.decompressData(payload);
             const data = JSON.parse(decompressed);
+            ConnectionUtils.validatePayload(data);
 
             if (type === 'offer') {
                 // -------------------------------------------------------
@@ -521,7 +532,9 @@ export class P2PUIManager {
             try {
                 this.logDiag('info', 'Attempting to unpack pasted string...');
                 const decompressed = await ConnectionUtils.decompressData(text);
-                this.currentScanSuccessCallback(JSON.parse(decompressed));
+                const parsed = JSON.parse(decompressed);
+                ConnectionUtils.validatePayload(parsed);
+                this.currentScanSuccessCallback(parsed);
                 this.ui.pasteInput.value = '';
                 if(this.html5QrcodeScanner) try { this.html5QrcodeScanner.clear(); } catch(e){}
                 this.ui.scannerContainer.style.display = 'none';
@@ -576,6 +589,7 @@ export class P2PUIManager {
             try {
                 const decompressed = await ConnectionUtils.decompressData(decodedText);
                 const data = JSON.parse(decompressed);
+                ConnectionUtils.validatePayload(data);
                 onSuccess(data);
             } catch (e) {
                 this.logDiag('error', `Failed Data Decompression: ${e.message}`);
@@ -600,5 +614,31 @@ export class P2PUIManager {
             this.ui.qrPlaceholder.style.display = 'block';
         }
         if(this.html5QrcodeScanner) { try { this.html5QrcodeScanner.clear(); } catch(e){} }
+    }
+
+    /**
+     * Fully tears down the UI manager: closes BroadcastChannel, removes window
+     * event listeners, stops any active QR scanner, and removes the DOM overlay.
+     * After calling destroy(), this instance should not be reused.
+     */
+    destroy() {
+        // Stop camera / scanner if active
+        if (this.html5QrcodeScanner) {
+            try { this.html5QrcodeScanner.clear(); } catch(_) {}
+            this.html5QrcodeScanner = null;
+        }
+        // Close BroadcastChannel
+        try { this.bc?.close(); } catch(_) {}
+        // Remove window event listeners
+        if (this._storageListener) {
+            window.removeEventListener('storage', this._storageListener);
+            this._storageListener = null;
+        }
+        if (this._messageListener) {
+            window.removeEventListener('message', this._messageListener);
+            this._messageListener = null;
+        }
+        // Remove injected DOM
+        this.ui?.overlay?.remove();
     }
 }


### PR DESCRIPTION
Resolves #5 and #6.

## Summary

### Issue #5 — destroy() / disconnect() API
- Added P2PAddon.destroy() that chains through all layers
- Added PeerManager.destroy() — closes all RTCPeerConnection + data channels, clears peers Map
- Added P2PUIManager.destroy() — stops QR scanner (releases camera), closes BroadcastChannel, removes storage and message window listeners by ref, removes injected modal DOM
- Updated p2p-integration-guide.md to document the new API

### Issue #6 — SDP payload validation
- Added ConnectionUtils.validatePayload() static utility — checks shape is a plain object, required fields are present, and sessionDesc has valid type/sdp string fields
- Applied validation at all 5 entry points: _ingestURLPayload, startScanner callback, paste handler, _tryApplyAnswer (inter-tab channels)
- Fixed Object.assign({}, parsed, ...) in setupDataChannel — now destructures only { text, from } to prevent arbitrary key injection into event details